### PR TITLE
Temporarily remove the new Migration Analytics menu entry

### DIFF
--- a/lib/cfme/migration_analytics/engine.rb
+++ b/lib/cfme/migration_analytics/engine.rb
@@ -15,11 +15,12 @@ module Cfme
         app.config.assets.paths  << root.join('assets', 'images').to_s
       end
 
-      initializer 'plugin-migration-analytics-menu', {:after => 'plugin-migration-menu'} do
-        Menu::CustomLoader.register(
-          Menu::Item.new('migration_analytics', N_('Migration Analytics'), 'migration_analytics', {:feature => 'migration_analytics', :any => true}, '/migration_analytics', :default, :migration)
-        )
-      end
+      # This plugin's menu entry has been removed temporarily while it is incomplete. When the data collection functionality is working, we will un-comment these lines.
+      # initializer 'plugin-migration-analytics-menu', {:after => 'plugin-migration-menu'} do
+      #   Menu::CustomLoader.register(
+      #     Menu::Item.new('migration_analytics', N_('Migration Analytics'), 'migration_analytics', {:feature => 'migration_analytics', :any => true}, '/migration_analytics', :default, :migration)
+      #   )
+      # end
     end
   end
 end

--- a/lib/cfme/migration_analytics/engine.rb
+++ b/lib/cfme/migration_analytics/engine.rb
@@ -4,7 +4,7 @@ module Cfme
       isolate_namespace Cfme::MigrationAnalytics
 
       def self.vmdb_plugin?
-        true
+        false # TODO: this should be changed back to true when we re-enable the menu entry below
       end
 
       def self.plugin_name


### PR DESCRIPTION
Since we don't yet have support for running the data collector from the UI, @bthurber asked me to disable this plugin's UI until it is fully functional so we're not exposing a placeholder to customers.

I simply commented out the menu initializer, so for development and PR review we just need to un-comment these lines for now. @Fryguy if there is some more elegant way to switch this off I'm happy to do that instead.

I created the issue #5 to track this, we should close that issue when we revert this commit.