### PR TITLE
Add default manifest and API controller for loading it

### DIFF
--- a/app/controllers/api/migration_analytics_manifest_controller.rb
+++ b/app/controllers/api/migration_analytics_manifest_controller.rb
@@ -1,25 +1,17 @@
-def parse_json_if_valid(json)
-    return JSON.parse(json)
-  rescue JSON::ParserError => e
-    return :invalid
-end
-
 module Api
   class MigrationAnalyticsManifestController < BaseController
+
     def index
       tmp_manifest_path = '/tmp/migration-analytics-manifest.json'
-      tmp_manifest = File.file?(tmp_manifest_path) ? parse_json_if_valid(File.read(tmp_manifest_path)) : nil
+      tmp_manifest = File.file?(tmp_manifest_path) ? load_manifest(tmp_manifest_path) : nil
       tmp_manifest_valid = tmp_manifest != nil && tmp_manifest != :invalid
 
       if tmp_manifest_valid
         manifest_path = tmp_manifest_path
         manifest = tmp_manifest
       else
-        manifest_path = File.join(
-          Bundler.environment.specs['cfme-migration_analytics'].first.full_gem_path,
-          'config/default-manifest.json'
-        )
-        manifest = parse_json_if_valid(File.read(manifest_path))
+        manifest_path = Cfme::MigrationAnalytics::Engine.root.join('config', 'default-manifest.json')
+        manifest = load_manifest(manifest_path)
       end
 
       res = {
@@ -30,5 +22,14 @@ module Api
       }
       render_resource :migration_analytics_manifest, res
     end
+
+    private
+
+    def load_manifest(path)
+        JSON.parse(File.read(path))
+      rescue JSON::ParserError
+        :invalid
+    end
+
   end
 end

--- a/app/controllers/api/migration_analytics_manifest_controller.rb
+++ b/app/controllers/api/migration_analytics_manifest_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  class MigrationAnalyticsManifestController < BaseController
+    def index
+      res = {
+        :hello => 'world'
+      }
+      render_resource :migration_analytics_manifest, res
+    end
+  end
+end

--- a/app/controllers/api/migration_analytics_manifest_controller.rb
+++ b/app/controllers/api/migration_analytics_manifest_controller.rb
@@ -2,21 +2,10 @@ module Api
   class MigrationAnalyticsManifestController < BaseController
 
     def index
-      tmp_manifest_path = '/tmp/migration-analytics-manifest.json'
-      tmp_manifest = File.file?(tmp_manifest_path) ? load_manifest(tmp_manifest_path) : nil
-      tmp_manifest_valid = tmp_manifest != nil && tmp_manifest != :invalid
-
-      if tmp_manifest_valid
-        manifest_path = tmp_manifest_path
-        manifest = tmp_manifest
-      else
-        manifest_path = Cfme::MigrationAnalytics::Engine.root.join('config', 'default-manifest.json')
-        manifest = load_manifest(manifest_path)
-      end
+      manifest_path = Cfme::MigrationAnalytics::Engine.root.join('config', 'default-manifest.json')
+      manifest = load_manifest(manifest_path)
 
       res = {
-        :tmp_manifest_present => tmp_manifest != nil,
-        :tmp_manifest_valid => tmp_manifest_valid,
         :path => manifest_path,
         :body => manifest,
       }
@@ -28,7 +17,7 @@ module Api
     def load_manifest(path)
         JSON.parse(File.read(path))
       rescue JSON::ParserError
-        :invalid
+        nil
     end
 
   end

--- a/app/controllers/api/migration_analytics_manifest_controller.rb
+++ b/app/controllers/api/migration_analytics_manifest_controller.rb
@@ -1,8 +1,32 @@
+def parse_json_if_valid(json)
+    return JSON.parse(json)
+  rescue JSON::ParserError => e
+    return :invalid
+end
+
 module Api
   class MigrationAnalyticsManifestController < BaseController
     def index
+      tmp_manifest_path = '/tmp/migration-analytics-manifest.json'
+      tmp_manifest = File.file?(tmp_manifest_path) ? parse_json_if_valid(File.read(tmp_manifest_path)) : nil
+      tmp_manifest_valid = tmp_manifest != nil && tmp_manifest != :invalid
+
+      if tmp_manifest_valid
+        manifest_path = tmp_manifest_path
+        manifest = tmp_manifest
+      else
+        manifest_path = File.join(
+          Bundler.environment.specs['cfme-migration_analytics'].first.full_gem_path,
+          'config/default-manifest.json'
+        )
+        manifest = parse_json_if_valid(File.read(manifest_path))
+      end
+
       res = {
-        :hello => 'world'
+        :tmp_manifest_present => tmp_manifest != nil,
+        :tmp_manifest_valid => tmp_manifest_valid,
+        :path => manifest_path,
+        :body => manifest,
       }
       render_resource :migration_analytics_manifest, res
     end

--- a/cfme-migration_analytics.gemspec
+++ b/cfme-migration_analytics.gemspec
@@ -1,7 +1,5 @@
 $:.push File.expand_path("../lib", __FILE__)
 
-require "json"
-
 # Maintain your gem's version:
 require "cfme/migration_analytics/version"
 

--- a/cfme-migration_analytics.gemspec
+++ b/cfme-migration_analytics.gemspec
@@ -1,5 +1,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
+require "json"
+
 # Maintain your gem's version:
 require "cfme/migration_analytics/version"
 

--- a/config/api.yml
+++ b/config/api.yml
@@ -7,3 +7,7 @@
     :identifier: migration_analytics_manifest
     :verbs:
     - :get
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: red_hat_cloud_services

--- a/config/api.yml
+++ b/config/api.yml
@@ -1,0 +1,9 @@
+:collections:
+  :migration_analytics_manifest:
+    :description: Migration Analytics Manifest
+    :options:
+    - :arbitrary_resource_path
+    - :collection
+    :identifier: migration_analytics_manifest
+    :verbs:
+    - :get

--- a/config/default-manifest.json
+++ b/config/default-manifest.json
@@ -1,0 +1,349 @@
+{
+  "cfme_version": "5.11",
+  "manifest": {
+    "version": "1.0.0",
+    "core": {
+      "MiqDatabase": {
+        "id": null,
+        "guid": null,
+        "region_number": null,
+        "region_description": null
+      },
+      "Zone": {
+        "id": null,
+        "name": null
+      }
+    },
+    "ManageIQ::Providers::OpenStack::CloudManager": {
+      "id": null,
+      "name": null,
+      "type": null,
+      "guid": null,
+      "api_version": null,
+      "emstype_description": null,
+      "hostname": null,
+      "vms": {
+        "id": null,
+        "name": null,
+        "description": null,
+        "type": null,
+        "uid_ems": null,
+        "cpu_cores_per_socket": null,
+        "cpu_total_cores": null,
+        "disks_aligned": null,
+        "ems_ref": null,
+        "has_rdm_disk": null,
+        "power_state": null,
+        "ram_size_in_bytes": null,
+        "retired": null,
+        "v_datastore_path": null,
+        "operating_system": {
+          "product_type": null,
+          "product_name": null,
+          "distribution": null
+        },
+        "hardware": {
+          "id": null,
+          "guest_os_full_name": null,
+          "disks": {
+            "id": null,
+            "device_name": null,
+            "device_type": null,
+            "disk_type": null,
+            "filename": null,
+            "free_space": null,
+            "mode": null,
+            "size": null,
+            "size_on_disk": null
+          },
+          "nics": {
+            "id": null,
+            "device_name": null,
+            "device_type": null,
+            "address": null,
+            "model": null,
+            "uid_ems": null,
+            "network": {
+              "id": null,
+              "ipaddress": null,
+              "hostname": null
+            }
+          }
+        },
+        "files": {
+          "id": null,
+          "name": null,
+          "contents": null
+        },
+        "system_services": {
+          "id": null,
+          "name": null,
+          "typename": null
+        }
+      }
+    },
+    "ManageIQ::Providers::Redhat::InfraManager": {
+      "id": null,
+      "name": null,
+      "type": null,
+      "guid": null,
+      "api_version": null,
+      "emstype_description": null,
+      "hostname": null,
+      "vms": {
+        "id": null,
+        "name": null,
+        "description": null,
+        "type": null,
+        "uid_ems": null,
+        "cpu_cores_per_socket": null,
+        "cpu_total_cores": null,
+        "disks_aligned": null,
+        "ems_ref": null,
+        "has_rdm_disk": null,
+        "host": {
+          "ems_ref": null
+        },
+        "power_state": null,
+        "ram_size_in_bytes": null,
+        "retired": null,
+        "v_datastore_path": null,
+        "operating_system": {
+          "product_type": null,
+          "product_name": null,
+          "distribution": null
+        },
+        "hardware": {
+          "id": null,
+          "guest_os_full_name": null,
+          "disks": {
+            "id": null,
+            "device_name": null,
+            "device_type": null,
+            "disk_type": null,
+            "filename": null,
+            "free_space": null,
+            "mode": null,
+            "size": null,
+            "size_on_disk": null
+          },
+          "nics": {
+            "id": null,
+            "device_name": null,
+            "device_type": null,
+            "address": null,
+            "model": null,
+            "uid_ems": null,
+            "network": {
+              "id": null,
+              "ipaddress": null,
+              "hostname": null
+            }
+          }
+        },
+        "files": {
+          "id": null,
+          "name": null,
+          "contents": null
+        },
+        "system_services": {
+          "id": null,
+          "name": null,
+          "typename": null
+        }
+      },
+      "ems_clusters": {
+        "id": null,
+        "name": null,
+        "uid_ems": null,
+        "ems_ref": null,
+        "ha_enabled": null,
+        "drs_enabled": null,
+        "effective_cpu": null,
+        "effective_memory": null
+      },
+      "hosts": {
+        "id": null,
+        "name": null,
+        "type": null,
+        "hostname": null,
+        "ipaddress": null,
+        "power_state": null,
+        "guid": null,
+        "uid_ems": null,
+        "ems_ref": null,
+        "mac_address": null,
+        "maintenance": null,
+        "vmm_vendor": null,
+        "vmm_version": null,
+        "vmm_product": null,
+        "vmm_buildnumber": null,
+        "archived": null,
+        "cpu_cores_per_socket": null,
+        "cpu_total_cores": null,
+        "ems_cluster": {
+          "ems_ref": null
+        },
+        "hardware": {
+          "memory_mb": null
+        }
+      },
+      "storages": {
+        "id": null,
+        "name": null,
+        "location": null,
+        "store_type": null,
+        "total_space": null,
+        "free_space": null,
+        "uncommitted": null,
+        "storage_domain_type": null,
+        "host_storages": {
+          "ems_ref": null,
+          "host": {
+            "ems_ref": null
+          }
+        }
+      }
+    },
+    "ManageIQ::Providers::Vmware::InfraManager": {
+      "id": null,
+      "name": null,
+      "type": null,
+      "guid": null,
+      "api_version": null,
+      "emstype_description": null,
+      "hostname": null,
+      "vms": {
+        "id": null,
+        "name": null,
+        "description": null,
+        "type": null,
+        "uid_ems": null,
+        "cpu_cores_per_socket": null,
+        "cpu_total_cores": null,
+        "disks_aligned": null,
+        "ems_ref": null,
+        "has_rdm_disk": null,
+        "host": {
+          "ems_ref": null
+        },
+        "power_state": null,
+        "ram_size_in_bytes": null,
+        "retired": null,
+        "v_datastore_path": null,
+        "operating_system": {
+          "product_type": null,
+          "product_name": null,
+          "distribution": null
+        },
+        "hardware": {
+          "id": null,
+          "guest_os_full_name": null,
+          "disks": {
+            "id": null,
+            "device_name": null,
+            "device_type": null,
+            "disk_type": null,
+            "filename": null,
+            "free_space": null,
+            "mode": null,
+            "size": null,
+            "size_on_disk": null
+          },
+          "nics": {
+            "id": null,
+            "device_name": null,
+            "device_type": null,
+            "address": null,
+            "model": null,
+            "uid_ems": null,
+            "network": {
+              "id": null,
+              "ipaddress": null,
+              "hostname": null
+            }
+          }
+        },
+        "files": {
+          "id": null,
+          "name": null,
+          "contents": null
+        },
+        "system_services": {
+          "id": null,
+          "name": null,
+          "typename": null
+        }
+      },
+      "ems_extensions": {
+        "id": null,
+        "ems_ref": null,
+        "key": null,
+        "company": null,
+        "label": null,
+        "summary": null,
+        "version": null
+      },
+      "ems_licenses": {
+        "id": null,
+        "ems_ref": null,
+        "name": null,
+        "license_edition": null,
+        "total_licenses": null,
+        "used_licenses": null
+      },
+      "ems_clusters": {
+        "id": null,
+        "name": null,
+        "uid_ems": null,
+        "ems_ref": null,
+        "ha_enabled": null,
+        "drs_enabled": null,
+        "effective_cpu": null,
+        "effective_memory": null
+      },
+      "hosts": {
+        "id": null,
+        "name": null,
+        "type": null,
+        "hostname": null,
+        "ipaddress": null,
+        "power_state": null,
+        "guid": null,
+        "uid_ems": null,
+        "ems_ref": null,
+        "mac_address": null,
+        "maintenance": null,
+        "vmm_vendor": null,
+        "vmm_version": null,
+        "vmm_product": null,
+        "vmm_buildnumber": null,
+        "archived": null,
+        "cpu_cores_per_socket": null,
+        "cpu_total_cores": null,
+        "ems_cluster": {
+          "ems_ref": null
+        },
+        "hardware": {
+          "memory_mb": null
+        }
+      },
+      "storages": {
+        "id": null,
+        "name": null,
+        "location": null,
+        "store_type": null,
+        "total_space": null,
+        "free_space": null,
+        "uncommitted": null,
+        "storage_domain_type": null,
+        "host_storages": {
+          "ems_ref": null,
+          "host": {
+            "ems_ref": null
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a copy of the v1.0.0 manifest at `config/default-manifest.json`, and adds a new API endpoint at `/api/migration_analytics_manifest` for fetching it in the UI.

The API call will:
* Check to see if there is a user-provided manifest at `/tmp/migration-analytics-manifest.json` on the appliance, and use that manifest if it is present and contains valid JSON.
* If no valid tmp_manifest is present, it will instead use the default manifest stored in the gem.
* Return an object with the following properties:
  * `tmp_manifest_present` (boolean) - whether or not there is a file at /tmp/migration-analytics-manifest.json
  * `tmp_manifest_valid` (boolean) - whether or not there is a valid JSON file at /tmp/migration-analytics-manifest.json
  * `path` (string) - the path to the manifest JSON file being used
  * `body` (object) - the parsed contents of the manifest JSON

We can use this to load a manifest into the UI, and:
* Display the current version of that manifest
* Indicate whether the user's manually provided manifest is being used or is invalid
* Pass it to the data collector API (still to be developed).