### PR TITLE
Add new red_hat_migration_analytics product feature

### DIFF
--- a/app/controllers/api/migration_analytics_manifest_controller.rb
+++ b/app/controllers/api/migration_analytics_manifest_controller.rb
@@ -2,7 +2,7 @@ module Api
   class MigrationAnalyticsManifestController < BaseController
 
     def index
-      manifest_path = Cfme::MigrationAnalytics::Engine.root.join('config', 'default-manifest.json')
+      manifest_path = Cfme::MigrationAnalytics::Engine.root.join("config", "default-manifest.json")
       manifest = load_manifest(manifest_path)
 
       res = {

--- a/app/controllers/migration_analytics_controller.rb
+++ b/app/controllers/migration_analytics_controller.rb
@@ -3,8 +3,8 @@ class MigrationAnalyticsController < ApplicationController
   after_action :cleanup_action
 
   def index
-    @layout = 'migration_analytics'
-    @page_title = _('Migration Analytics')
+    @layout = "migration_analytics"
+    @page_title = _("Migration Analytics")
   end
 
   helper do

--- a/app/mailers/cfme/migration_analytics/application_mailer.rb
+++ b/app/mailers/cfme/migration_analytics/application_mailer.rb
@@ -1,8 +1,8 @@
 module Cfme
   module MigrationAnalytics
     class ApplicationMailer < ActionMailer::Base
-      default from: 'from@example.com'
-      layout 'mailer'
+      default from: "from@example.com"
+      layout "mailer"
     end
   end
 end

--- a/config/api.yml
+++ b/config/api.yml
@@ -10,4 +10,4 @@
     :collection_actions:
       :get:
       - :name: read
-        :identifier: red_hat_cloud_services
+        :identifier: red_hat_migration_analytics

--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,6 +1,6 @@
 Vmdb::Gettext::Domains.add_domain(
-  'Cfme::MigrationAnalytics',
-  Cfme::MigrationAnalytics::Engine.root.join('locale').to_s,
+  "Cfme::MigrationAnalytics",
+  Cfme::MigrationAnalytics::Engine.root.join("locale").to_s,
   :po
 )
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  get '/migration_analytics', to: 'migration_analytics#index'
+  get "/migration_analytics", to: "migration_analytics#index"
 end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1,0 +1,6 @@
+---
+# Red Hat Migration Analytics
+- :name: Red Hat Migration Analytics
+  :description: Everything under Red Hat Migration Analytics
+  :feature_type: node
+  :identifier: red_hat_migration_analytics

--- a/lib/cfme/migration_analytics/engine.rb
+++ b/lib/cfme/migration_analytics/engine.rb
@@ -8,17 +8,17 @@ module Cfme
       end
 
       def self.plugin_name
-        _('Red Hat Migration Analytics')
+        _("Red Hat Migration Analytics")
       end
 
-      initializer 'plugin.assets' do |app|
-        app.config.assets.paths  << root.join('assets', 'images').to_s
+      initializer "plugin.assets" do |app|
+        app.config.assets.paths  << root.join("assets", "images").to_s
       end
 
-      # This plugin's menu entry has been removed temporarily while it is incomplete. When the data collection functionality is working, we will un-comment these lines.
-      # initializer 'plugin-migration-analytics-menu', {:after => 'plugin-migration-menu'} do
+      # This plugin"s menu entry has been removed temporarily while it is incomplete. When the data collection functionality is working, we will un-comment these lines.
+      # initializer "plugin-migration-analytics-menu", {:after => "plugin-migration-menu"} do
       #   Menu::CustomLoader.register(
-      #     Menu::Item.new('migration_analytics', N_('Migration Analytics'), 'migration_analytics', {:feature => 'migration_analytics', :any => true}, '/migration_analytics', :default, :migration)
+      #     Menu::Item.new("migration_analytics", N_("Migration Analytics"), "migration_analytics", {:feature => "migration_analytics", :any => true}, "/migration_analytics", :default, :migration)
       #   )
       # end
     end

--- a/lib/cfme/migration_analytics/version.rb
+++ b/lib/cfme/migration_analytics/version.rb
@@ -1,5 +1,5 @@
 module Cfme
   module MigrationAnalytics
-    VERSION = '0.1.0'.freeze
+    VERSION = "0.1.0".freeze
   end
 end


### PR DESCRIPTION
This PR switches the new API endpoint from the existing `red_hat_cloud_services` product feature to a new `red_hat_migration_analytics` feature. (see https://github.com/RedHatCloudForms/cfme-migration_analytics/pull/8#discussion_r311688618)

This PR also converts all `'single-quotes'` in the repo's Ruby files to `"double-quotes"`. (see https://github.com/RedHatCloudForms/cfme-migration_analytics/pull/8#discussion_r311680773)