### PR TITLE
Filter out any password from the manifest

### DIFF
--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -32,7 +32,7 @@ module Api
     private
 
     def find_provider_ids(type)
-      providers, _ = collection_search(false, type, collection_class(type))
+      providers, _ = collection_search(false, :providers, collection_class(:providers))
       providers ? providers.ids.sort : []
     end
 

--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -2,7 +2,7 @@ module Api
   class RedHatMigrationAnalyticsController < BaseController
     def index
       manifest_path = Cfme::MigrationAnalytics::Engine.root.join("config", "default-manifest.json")
-      manifest = load_manifest(manifest_path)
+      manifest = self.class.load_manifest(manifest_path)
 
       res = {
         :path => manifest_path,
@@ -13,7 +13,7 @@ module Api
 
     def bundle_collection(type, data)
       manifest_path = Cfme::MigrationAnalytics::Engine.root.join("config", "default-manifest.json")
-      manifest = load_manifest(manifest_path)
+      manifest = self.class.load_manifest(manifest_path)
       provider_ids = data["provider_ids"]
       provider_ids = provider_ids.uniq if provider_ids
       raise "Must specify a list of provider ids via \"provider_ids\"" if provider_ids.blank?
@@ -31,15 +31,17 @@ module Api
 
     private
 
-    def load_manifest(path)
-      Vmdb::Settings.filter_passwords!(JSON.parse(File.read(path)))
-    rescue JSON::ParserError
-      nil
-    end
-
     def find_provider_ids(type)
       providers, _ = collection_search(false, type, collection_class(type))
       providers ? providers.ids.sort : []
+    end
+
+    class << self
+      def load_manifest(path)
+        Vmdb::Settings.filter_passwords!(JSON.parse(File.read(path)))
+      rescue JSON::ParserError
+        nil
+      end
     end
   end
 end

--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -32,7 +32,7 @@ module Api
     private
 
     def load_manifest(path)
-      JSON.parse(File.read(path))
+      Vmdb::Settings.filter_passwords!(JSON.parse(File.read(path)))
     rescue JSON::ParserError
       nil
     end

--- a/spec/requests/red_hat_migration_analytics_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_spec.rb
@@ -39,6 +39,7 @@ describe "Red Hat  Migration Analytics Manifest API" do
 
       ems1 = FactoryBot.create(:ems_vmware, :name => "sample vmware1")
 
+      expect(Api::RedHatMigrationAnalyticsController).to receive(:load_manifest).and_return(manifest)
       allow(Cfme::CloudServices::InventorySync).to receive("bundle_queue").with(@user.userid, manifest, [ems1.id]) { task.id }
 
       post(api_red_hat_migration_analytics_url,

--- a/spec/requests/red_hat_migration_analytics_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_spec.rb
@@ -15,6 +15,21 @@ describe "Red Hat  Migration Analytics Manifest API" do
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body["body"]).to match(a_hash_including("cfme_version"=>"5.11"))
       end
+
+      it "filters out passwords from the manifest" do
+        malicious_manifest = {
+          "password"      => nil,
+          "amazon_secret" => nil,
+          "ssh_key_data"  => nil
+        }
+
+        expect(Api::RedHatMigrationAnalyticsController).to receive(:load_manifest).and_return(malicious_manifest)
+
+        get(api_red_hat_migration_analytics_url)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["body"]).to eq({})
+      end
     end
   end
 

--- a/spec/requests/red_hat_migration_analytics_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_spec.rb
@@ -3,6 +3,21 @@ describe "Red Hat  Migration Analytics Manifest API" do
   let(:manifest) { { "ManageIQ::Providers::Vmware::InfraManager" => {}} }
   let(:task) { FactoryBot.create(:miq_task) }
 
+  describe "GET" do
+    context "/api/red_hat_migration_analytics index action" do
+      before do
+        api_basic_authorize "red_hat_migration_analytics"
+      end
+
+      it "with the built-in manifest" do
+        get(api_red_hat_migration_analytics_url)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["body"]).to match(a_hash_including("cfme_version"=>"5.11"))
+      end
+    end
+  end
+
   describe "POST" do
     it "/api/red_hat_migration_analytics/:id bundle action" do
       api_basic_authorize "red_hat_migration_analytics"


### PR DESCRIPTION
Mitigate issues where someone could upload a manifest with the intention
of collecting passwords from the database by stripping out any of the
"password" fields defined in Vmdb::SettingsWalker