### PR TITLE
Fetch and display manifest version in UI, prepare for data collection

### DIFF
--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -2,7 +2,7 @@ module Api
   class RedHatMigrationAnalyticsController < BaseController
     def index
       check_feature_enabled
-      manifest = self.class.load_manifest
+      manifest = self.class.parse_manifest
       res = {
         :manifest_version => manifest[:version],
         :using_default_manifest => manifest[:using_default]
@@ -42,10 +42,10 @@ module Api
     end
 
     class << self
-      def load_manifest
+      def parse_manifest
         # TODO: check for a valid user-provided manifest before defaulting to default-manifest.json
         manifest_path = Cfme::MigrationAnalytics::Engine.root.join("config", "default-manifest.json")
-        manifest = parse_manifest(manifest_path)
+        manifest = Vmdb::Settings.filter_passwords!(load_manifest(manifest_path))
         {
           :path => manifest_path,
           :body => manifest,
@@ -54,8 +54,8 @@ module Api
         }
       end
 
-      def parse_manifest(path)
-        Vmdb::Settings.filter_passwords!(JSON.parse(File.read(path)))
+      def load_manifest(path)
+        JSON.parse(File.read(path))
       rescue JSON::ParserError
         nil
       end

--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -2,20 +2,17 @@ module Api
   class RedHatMigrationAnalyticsController < BaseController
     def index
       check_feature_enabled
-      manifest_path = Cfme::MigrationAnalytics::Engine.root.join("config", "default-manifest.json")
-      manifest = self.class.load_manifest(manifest_path)
-
+      manifest = load_manifest
       res = {
-        :path => manifest_path,
-        :body => manifest,
+        :manifest_version => manifest[:version],
+        :using_default_manifest => manifest[:using_default]
       }
-      render_resource :migration_analytics_manifest, res
+      render_resource :red_hat_migration_analytics, res
     end
 
     def bundle_collection(type, data)
       check_feature_enabled
-      manifest_path = Cfme::MigrationAnalytics::Engine.root.join("config", "default-manifest.json")
-      manifest = self.class.load_manifest(manifest_path)
+      manifest = load_manifest[:body]
       provider_ids = data["provider_ids"]
       provider_ids = provider_ids.uniq if provider_ids
       raise "Must specify a list of provider ids via \"provider_ids\"" if provider_ids.blank?
@@ -38,6 +35,18 @@ module Api
         raise ActionController::RoutingError, 'Feature Not Enabled'
       end
     end
+    
+    def load_manifest
+      # TODO: check for a valid user-provided manifest before defaulting to default-manifest.json
+      manifest_path = Cfme::MigrationAnalytics::Engine.root.join("config", "default-manifest.json")
+      manifest = self.class.parse_manifest(manifest_path)
+      {
+        :path => manifest_path,
+        :body => manifest,
+        :version => manifest["manifest"]["version"],
+        :using_default => true
+      }
+    end
 
     def find_provider_ids(type)
       providers, _ = collection_search(false, :providers, collection_class(:providers))
@@ -45,7 +54,7 @@ module Api
     end
 
     class << self
-      def load_manifest(path)
+      def parse_manifest(path)
         Vmdb::Settings.filter_passwords!(JSON.parse(File.read(path)))
       rescue JSON::ParserError
         nil

--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -12,7 +12,7 @@ module Api
 
     def bundle_collection(type, data)
       check_feature_enabled
-      manifest = self.class.load_manifest[:body]
+      manifest = self.class.parse_manifest[:body]
       provider_ids = data["provider_ids"]
       provider_ids = provider_ids.uniq if provider_ids
       raise "Must specify a list of provider ids via \"provider_ids\"" if provider_ids.blank?

--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -49,7 +49,7 @@ module Api
         {
           :path => manifest_path,
           :body => manifest,
-          :version => manifest["manifest"]["version"],
+          :version => manifest.dig("manifest", "version"),
           :using_default => true
         }
       end

--- a/app/javascript/react/index.js
+++ b/app/javascript/react/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import Analytics from './screens/App/Analytics/Analytics';
+import Analytics from './screens/App/Analytics';
 import createReducers from '../redux/createReducers';
 
 class App extends React.Component {

--- a/app/javascript/react/screens/App/Analytics/Analytics.js
+++ b/app/javascript/react/screens/App/Analytics/Analytics.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Breadcrumb } from 'patternfly-react';
 import Toolbar from './components/Toolbar';
 import AnalyticsEmptyState from './screens/AnalyticsEmptyState';
@@ -13,16 +12,6 @@ const SCREENS = {
   SUMMARY: 'SUMMARY',
   PROVIDER_SELECTION: 'PROVIDER_SELECTION',
   DATA_COLLECTION: 'DATA_COLLECTION'
-};
-
-const AnalyticsContainer = ({ currentScreen, children }) => (
-  <div id="migration-analytics" className={currentScreen === SCREENS.EMPTY_STATE ? 'row cards-pf' : ''}>
-    {children}
-  </div>
-);
-AnalyticsContainer.propTypes = {
-  currentScreen: PropTypes.oneOf(Object.values(SCREENS)).isRequired,
-  children: PropTypes.node.isRequired
 };
 
 class Analytics extends React.Component {
@@ -48,6 +37,7 @@ class Analytics extends React.Component {
 
   render() {
     const { currentScreen } = this.state;
+    const onEmptyState = currentScreen === SCREENS.EMPTY_STATE;
     return (
       <React.Fragment>
         <Toolbar>
@@ -59,7 +49,12 @@ class Analytics extends React.Component {
           {/* <BreadcrumbPageSwitcher activeHref="#/analytics" /> */}
           {/* TODO: figure out how to share the breadcrumb switcher with v2v */}
         </Toolbar>
-        <AnalyticsContainer currentScreen={currentScreen}>{this.renderCurrentScreen()}</AnalyticsContainer>
+        <div id="migration-analytics" className={onEmptyState ? 'row cards-pf' : ''}>
+          {this.renderCurrentScreen()}
+        </div>
+        <h6 id="migration-analytics-manifest-version" className={onEmptyState ? 'on-empty-state' : ''}>
+          Manifest Version: x.y.z
+        </h6>
       </React.Fragment>
     );
   }

--- a/app/javascript/react/screens/App/Analytics/Analytics.js
+++ b/app/javascript/react/screens/App/Analytics/Analytics.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Breadcrumb } from 'patternfly-react';
+import { Breadcrumb, noop } from 'patternfly-react';
 import Toolbar from './components/Toolbar';
 import AnalyticsEmptyState from './screens/AnalyticsEmptyState';
 import AnalyticsSummary from './screens/AnalyticsSummary';
@@ -71,7 +71,7 @@ class Analytics extends React.Component {
 }
 
 Analytics.propTypes = {
-  fetchManifestInfoAction: PropTypes.func.isRequired,
+  fetchManifestInfoAction: PropTypes.func,
   manifestInfo: PropTypes.shape({
     manifest_version: PropTypes.string,
     using_default_manifest: PropTypes.bool
@@ -79,6 +79,7 @@ Analytics.propTypes = {
 };
 
 Analytics.defaultProps = {
+  fetchManifestInfoAction: noop,
   manifestInfo: null
 };
 

--- a/app/javascript/react/screens/App/Analytics/Analytics.js
+++ b/app/javascript/react/screens/App/Analytics/Analytics.js
@@ -17,6 +17,10 @@ const SCREENS = {
 class Analytics extends React.Component {
   state = { currentScreen: SCREENS.EMPTY_STATE };
 
+  componentDidMount() {
+    // this.props.fetchManifestInfoAction();
+  }
+
   goToSummary = () => this.setState({ currentScreen: SCREENS.SUMMARY });
   goToProviderSelection = () => this.setState({ currentScreen: SCREENS.PROVIDER_SELECTION });
   goToDataCollection = () => this.setState({ currentScreen: SCREENS.DATA_COLLECTION });

--- a/app/javascript/react/screens/App/Analytics/Analytics.js
+++ b/app/javascript/react/screens/App/Analytics/Analytics.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Breadcrumb } from 'patternfly-react';
 import Toolbar from './components/Toolbar';
 import AnalyticsEmptyState from './screens/AnalyticsEmptyState';
@@ -18,7 +19,7 @@ class Analytics extends React.Component {
   state = { currentScreen: SCREENS.EMPTY_STATE };
 
   componentDidMount() {
-    // this.props.fetchManifestInfoAction();
+    this.props.fetchManifestInfoAction();
   }
 
   goToSummary = () => this.setState({ currentScreen: SCREENS.SUMMARY });
@@ -40,6 +41,7 @@ class Analytics extends React.Component {
   };
 
   render() {
+    const { manifestInfo } = this.props;
     const { currentScreen } = this.state;
     const onEmptyState = currentScreen === SCREENS.EMPTY_STATE;
     return (
@@ -56,12 +58,28 @@ class Analytics extends React.Component {
         <div id="migration-analytics" className={onEmptyState ? 'row cards-pf' : ''}>
           {this.renderCurrentScreen()}
         </div>
-        <h6 id="migration-analytics-manifest-version" className={onEmptyState ? 'on-empty-state' : ''}>
-          Manifest Version: x.y.z
-        </h6>
+        {manifestInfo && (
+          <h6 id="migration-analytics-manifest-version" className={onEmptyState ? 'on-empty-state' : ''}>
+            {__('Manifest version:')}
+            &nbsp;
+            {manifestInfo.manifest_version}
+          </h6>
+        )}
       </React.Fragment>
     );
   }
 }
+
+Analytics.propTypes = {
+  fetchManifestInfoAction: PropTypes.func.isRequired,
+  manifestInfo: PropTypes.shape({
+    manifest_version: PropTypes.string,
+    using_default_manifest: PropTypes.bool
+  })
+};
+
+Analytics.defaultProps = {
+  manifestInfo: null
+};
 
 export default Analytics;

--- a/app/javascript/react/screens/App/Analytics/Analytics.scss
+++ b/app/javascript/react/screens/App/Analytics/Analytics.scss
@@ -101,3 +101,16 @@
     }
   }
 }
+
+#migration-analytics-manifest-version {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  margin: 0;
+  padding: 15px;
+  background-color: #ffffff;
+
+  &.on-empty-state {
+    background-color: $color-pf-black-150;
+  }
+}

--- a/app/javascript/react/screens/App/Analytics/__tests__/Analytics.test.js
+++ b/app/javascript/react/screens/App/Analytics/__tests__/Analytics.test.js
@@ -40,14 +40,9 @@ describe('Analytics root component', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('renders container with cards-pf class for empty state', () => {
-    const component = shallow(<Analytics />);
-    expect(component.find('AnalyticsContainer').dive()).toMatchSnapshot();
-  });
-
-  test('renders container without cards-pf class for other screens', () => {
+  test('renders container without cards-pf class when not on empty state screen', () => {
     const component = shallowSummaryScreen();
-    expect(component.find('AnalyticsContainer').dive()).toMatchSnapshot();
+    expect(component.find('#migration-analytics')).toMatchSnapshot();
   });
 
   test('renders summary after clicking Get Started from empty state', () => {

--- a/app/javascript/react/screens/App/Analytics/__tests__/__snapshots__/Analytics.test.js.snap
+++ b/app/javascript/react/screens/App/Analytics/__tests__/__snapshots__/Analytics.test.js.snap
@@ -1,17 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Analytics root component renders container with cards-pf class for empty state 1`] = `
-<div
-  className="row cards-pf"
-  id="migration-analytics"
->
-  <AnalyticsEmptyState
-    onGetStartedClick={[Function]}
-  />
-</div>
-`;
-
-exports[`Analytics root component renders container without cards-pf class for other screens 1`] = `
+exports[`Analytics root component renders container without cards-pf class when not on empty state screen 1`] = `
 <div
   className=""
   id="migration-analytics"
@@ -43,12 +32,13 @@ exports[`Analytics root component renders toolbar and empty state correctly 1`] 
       </strong>
     </BreadcrumbItem>
   </Toolbar>
-  <AnalyticsContainer
-    currentScreen="EMPTY_STATE"
+  <div
+    className="row cards-pf"
+    id="migration-analytics"
   >
     <AnalyticsEmptyState
       onGetStartedClick={[Function]}
     />
-  </AnalyticsContainer>
+  </div>
 </Fragment>
 `;

--- a/app/javascript/react/screens/App/Analytics/index.js
+++ b/app/javascript/react/screens/App/Analytics/index.js
@@ -1,9 +1,12 @@
 import { connect } from 'react-redux';
 import Analytics from './Analytics';
+import { fetchManifestInfoAction } from './redux/analyticsActions';
 
-const fetchManifestInfoAction = () => {}; // TODO NOW
-
-const mapStateToProps = ({ migrationAnalytics: { manifestInfo } }) => ({ manifestInfo });
+const mapStateToProps = ({
+  migrationAnalytics: {
+    analytics: { manifestInfo }
+  }
+}) => ({ manifestInfo });
 
 export default connect(
   mapStateToProps,

--- a/app/javascript/react/screens/App/Analytics/index.js
+++ b/app/javascript/react/screens/App/Analytics/index.js
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux';
+import Analytics from './Analytics';
+
+const fetchManifestInfoAction = () => {}; // TODO NOW
+
+const mapStateToProps = ({ migrationAnalytics: { manifestInfo } }) => ({ manifestInfo });
+
+export default connect(
+  mapStateToProps,
+  { fetchManifestInfoAction }
+)(Analytics);

--- a/app/javascript/react/screens/App/Analytics/redux/analyticsActions.js
+++ b/app/javascript/react/screens/App/Analytics/redux/analyticsActions.js
@@ -1,5 +1,13 @@
-import { CALCULATE_SUMMARY_DATA, SELECT_PROVIDERS, SELECT_DETAILED_DATA } from './constants';
-import { simpleActionWithProperties } from '../../../../../redux/helpers';
+import {
+  CALCULATE_SUMMARY_DATA,
+  SELECT_PROVIDERS,
+  SELECT_DETAILED_DATA,
+  FETCH_MANIFEST_INFO,
+  MANIFEST_INFO_URL
+} from './constants';
+import { simpleActionWithProperties, basicFetchAction } from '../../../../../redux/helpers';
+
+export const fetchManifestInfoAction = () => basicFetchAction(FETCH_MANIFEST_INFO, MANIFEST_INFO_URL);
 
 export const calculateSummaryDataAction = results => simpleActionWithProperties(CALCULATE_SUMMARY_DATA, { results });
 

--- a/app/javascript/react/screens/App/Analytics/redux/analyticsReducer.js
+++ b/app/javascript/react/screens/App/Analytics/redux/analyticsReducer.js
@@ -1,16 +1,25 @@
 import Immutable from 'seamless-immutable';
-import { CALCULATE_SUMMARY_DATA, SELECT_PROVIDERS, SELECT_DETAILED_DATA } from './constants';
-import { functionLookupReducer } from '../../../../../redux/helpers';
+import { CALCULATE_SUMMARY_DATA, SELECT_PROVIDERS, SELECT_DETAILED_DATA, FETCH_MANIFEST_INFO } from './constants';
+import { functionLookupReducer, getHandlersForBasicFetchActions } from '../../../../../redux/helpers';
 import { calculateSummaryData } from './helpers';
 import { RESET_ALL_STATE } from '../../../../../redux/common/constants';
 
+const fetchManifestInfo = getHandlersForBasicFetchActions(
+  FETCH_MANIFEST_INFO,
+  'isFetchingManifestInfo',
+  'errorFetchingManifestInfo',
+  'manifestInfo'
+);
+
 export const initialState = Immutable({
+  ...fetchManifestInfo.initialState,
   summaryData: null,
   selectedProviders: [],
   detailedDataSelected: false
 });
 
 const actionHandlers = {
+  ...fetchManifestInfo.actionHandlers,
   [CALCULATE_SUMMARY_DATA]: (state, action) => state.set('summaryData', calculateSummaryData(action.results)),
   [SELECT_PROVIDERS]: (state, action) => state.set('selectedProviders', action.selectedProviders),
   [SELECT_DETAILED_DATA]: (state, action) => state.set('detailedDataSelected', action.detailedDataSelected),

--- a/app/javascript/react/screens/App/Analytics/redux/constants.js
+++ b/app/javascript/react/screens/App/Analytics/redux/constants.js
@@ -1,3 +1,6 @@
+export const FETCH_MANIFEST_INFO = 'MA_FETCH_MANIFEST_INFO';
 export const CALCULATE_SUMMARY_DATA = 'MA_CALCULATE_SUMMARY_DATA';
 export const SELECT_PROVIDERS = 'MA_SELECT_PROVIDERS';
 export const SELECT_DETAILED_DATA = 'MA_SELECT_DETAILED_DATA';
+
+export const MANIFEST_INFO_URL = '/api/red_hat_migration_analytics';

--- a/app/javascript/redux/__tests__/__snapshots__/createReducers.test.js.snap
+++ b/app/javascript/redux/__tests__/__snapshots__/createReducers.test.js.snap
@@ -4,6 +4,9 @@ exports[`create reducers produces a properly combined initial state 1`] = `
 Object {
   "analytics": Object {
     "detailedDataSelected": false,
+    "errorFetchingManifestInfo": null,
+    "isFetchingManifestInfo": false,
+    "manifestInfo": null,
     "selectedProviders": Array [],
     "summaryData": null,
   },

--- a/app/javascript/redux/helpers.js
+++ b/app/javascript/redux/helpers.js
@@ -7,11 +7,17 @@ export const functionLookupReducer = (initialState, actionHandlers) => (state = 
   return handler ? handler(state, action) : state;
 };
 
-export const getHandlersForFetchResourcesActions = (actionType, isFetchingKey, errorKey, resourcesKey) => ({
+export const getHandlersForBasicFetchActions = (
+  actionType,
+  isFetchingKey,
+  errorKey,
+  resourceKey,
+  getResource = data => data
+) => ({
   initialState: Immutable({
     [isFetchingKey]: false,
     [errorKey]: null,
-    [resourcesKey]: null
+    [resourceKey]: null
   }),
   actionHandlers: {
     [`${actionType}_PENDING`]: state => state.set(errorKey, null).set(isFetchingKey, true),
@@ -19,11 +25,14 @@ export const getHandlersForFetchResourcesActions = (actionType, isFetchingKey, e
       state
         .set(errorKey, null)
         .set(isFetchingKey, false)
-        .set(resourcesKey, action.payload.data.resources),
+        .set(resourceKey, getResource(action.payload.data)),
     [`${actionType}_REJECTED`]: (state, action) =>
       state.set(errorKey, action.payload.data.error).set(isFetchingKey, false)
   }
 });
+
+export const getHandlersForFetchResourcesActions = (actionType, isFetchingKey, errorKey, resourcesKey) =>
+  getHandlersForBasicFetchActions(actionType, isFetchingKey, errorKey, resourcesKey, data => data.resources);
 
 export const getHandlersForFetchActionsIndexedByHref = (actionType, fetchingHrefsKey, errorKey, payloadsByHrefKey) => ({
   initialState: Immutable({
@@ -57,6 +66,13 @@ export const filterResources = (resources, filterValues) =>
 
 export const findResource = (resources, filterValues) =>
   resources && resources.find(resource => resourceMatchesFilters(resource, filterValues));
+
+export const basicFetchAction = (type, href) => dispatch =>
+  dispatch({
+    type,
+    payload: API.get(new URI(href).toString()),
+    meta: { href }
+  });
 
 export const fetchExpandedResourcesAction = (type, href, filterValues, attributes) => dispatch => {
   const uri = new URI(href);

--- a/app/javascript/redux/reports/__tests__/reportsActions.test.js
+++ b/app/javascript/redux/reports/__tests__/reportsActions.test.js
@@ -1,10 +1,8 @@
 import { fetchReportsAction, runReportAction, fetchTaskAction, fetchResultAction } from '../reportsActions';
-import { fetchExpandedResourcesAction } from '../../helpers';
+import * as helpers from '../../helpers';
 import { FETCH_REPORTS, REPORTS_URL, RUN_REPORT, FETCH_TASK, FETCH_RESULT } from '../constants';
 import { mockStore } from '../../../common/testReduxHelpers';
 import { mockRequest, mockReset } from '../../../common/mockRequests';
-
-jest.mock('../../helpers');
 
 const store = mockStore();
 
@@ -15,6 +13,7 @@ afterEach(() => {
 
 describe('reports actions', () => {
   test('fetch reports action', () => {
+    const fetchExpandedResourcesAction = jest.spyOn(helpers, 'fetchExpandedResourcesAction');
     fetchReportsAction({ type: 'foo' });
     expect(fetchExpandedResourcesAction).toHaveBeenCalledWith(FETCH_REPORTS, REPORTS_URL, { type: 'foo' }, [
       'href',

--- a/app/javascript/redux/reports/reportsActions.js
+++ b/app/javascript/redux/reports/reportsActions.js
@@ -1,7 +1,7 @@
 import URI from 'urijs';
 import API from '../../common/API';
 import { FETCH_REPORTS, REPORTS_URL, RUN_REPORT, FETCH_TASK, FETCH_RESULT } from './constants';
-import { fetchExpandedResourcesAction } from '../helpers';
+import { fetchExpandedResourcesAction, basicFetchAction } from '../helpers';
 
 export const fetchReportsAction = filterValues =>
   fetchExpandedResourcesAction(FETCH_REPORTS, REPORTS_URL, filterValues, ['href', 'name', 'rpt_group']);
@@ -11,13 +11,6 @@ export const runReportAction = reportHref => dispatch =>
     type: RUN_REPORT,
     payload: API.post(new URI(reportHref).toString(), { action: 'run' }),
     meta: { href: reportHref }
-  });
-
-const basicFetchAction = (type, href) => dispatch =>
-  dispatch({
-    type,
-    payload: API.get(new URI(href).toString()),
-    meta: { href }
   });
 
 export const fetchTaskAction = taskHref => basicFetchAction(FETCH_TASK, taskHref);

--- a/config/api.yml
+++ b/config/api.yml
@@ -1,6 +1,6 @@
 :collections:
   :red_hat_migration_analytics:
-    :description: Migration Analytics Manifest
+    :description: Red Hat Migration Analytics
     :options:
     - :arbitrary_resource_path
     - :collection

--- a/spec/requests/red_hat_migration_analytics_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_spec.rb
@@ -13,7 +13,7 @@ describe "Red Hat  Migration Analytics Manifest API" do
         get(api_red_hat_migration_analytics_url)
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["body"]).to match(a_hash_including("cfme_version"=>"5.11"))
+        expect(response.parsed_body).to match({"manifest_version" => "1.0.0", "using_default_manifest" => true})
       end
 
       it "filters out passwords from the manifest" do
@@ -28,7 +28,7 @@ describe "Red Hat  Migration Analytics Manifest API" do
         get(api_red_hat_migration_analytics_url)
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body["body"]).to eq({})
+        expect(response.parsed_body).to match({"manifest_version" => nil, "using_default_manifest" => true})
       end
     end
   end

--- a/spec/requests/red_hat_migration_analytics_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_spec.rb
@@ -3,6 +3,8 @@ describe "Red Hat  Migration Analytics Manifest API" do
   let(:manifest) { { "ManageIQ::Providers::Vmware::InfraManager" => {}} }
   let(:task) { FactoryBot.create(:miq_task) }
 
+  before { stub_settings_merge(:prototype => {:migration_analytics => {:enabled => true}}) }
+
   describe "GET" do
     context "/api/red_hat_migration_analytics index action" do
       before do


### PR DESCRIPTION
The manifest version is now displayed in a fixed footer in the lower-right corner of the window (independent of scroll position, should there be enough data on screen for scrollbars to appear) It has a solid background with a little bit of padding, so in the event that there is scrollable content we won't have text overlapping other text. It looks like this:

![Screenshot 2019-08-13 18 15 43](https://user-images.githubusercontent.com/811963/62981221-b521b380-bdf6-11e9-85fe-aecff3fdf53a.png)

Disregard the branch name, the actual API call for the bundle action (#9) will be in another PR.