### PR TITLE
Add Settings.prototype.migration_analytics.enabled flag to disable the feature in a supported way, enable vmdb_plugin

### DIFF
--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class RedHatMigrationAnalyticsController < BaseController
     def index
+      check_feature_enabled
       manifest_path = Cfme::MigrationAnalytics::Engine.root.join("config", "default-manifest.json")
       manifest = self.class.load_manifest(manifest_path)
 
@@ -12,6 +13,7 @@ module Api
     end
 
     def bundle_collection(type, data)
+      check_feature_enabled
       manifest_path = Cfme::MigrationAnalytics::Engine.root.join("config", "default-manifest.json")
       manifest = self.class.load_manifest(manifest_path)
       provider_ids = data["provider_ids"]
@@ -30,6 +32,12 @@ module Api
     end
 
     private
+
+    def check_feature_enabled
+      unless Settings.prototype.migration_analytics.enabled
+        raise ActionController::RoutingError, 'Feature Not Enabled'
+      end
+    end
 
     def find_provider_ids(type)
       providers, _ = collection_search(false, :providers, collection_class(:providers))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  get "/migration_analytics", to: "migration_analytics#index"
+  if Settings.prototype.migration_analytics.enabled
+    get "/migration_analytics", to: "migration_analytics#index"
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,4 @@
+---
+:prototype:
+  :migration_analytics:
+    :enabled: false

--- a/lib/cfme/migration_analytics/engine.rb
+++ b/lib/cfme/migration_analytics/engine.rb
@@ -4,7 +4,7 @@ module Cfme
       isolate_namespace Cfme::MigrationAnalytics
 
       def self.vmdb_plugin?
-        false # TODO: this should be changed back to true when we re-enable the menu entry below
+        true
       end
 
       def self.plugin_name
@@ -15,12 +15,13 @@ module Cfme
         app.config.assets.paths  << root.join("assets", "images").to_s
       end
 
-      # This plugin"s menu entry has been removed temporarily while it is incomplete. When the data collection functionality is working, we will un-comment these lines.
-      # initializer "plugin-migration-analytics-menu", {:after => "plugin-migration-menu"} do
-      #   Menu::CustomLoader.register(
-      #     Menu::Item.new("migration_analytics", N_("Migration Analytics"), "migration_analytics", {:feature => "migration_analytics", :any => true}, "/migration_analytics", :default, :migration)
-      #   )
-      # end
+      initializer "plugin-migration-analytics-menu", {:after => "plugin-migration-menu"} do
+        if Settings.prototype.migration_analytics.enabled
+          Menu::CustomLoader.register(
+            Menu::Item.new("migration_analytics", N_("Migration Analytics"), "migration_analytics", {:feature => "migration_analytics", :any => true}, "/migration_analytics", :default, :migration)
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The way we were disabling this plugin by setting vmdb_plugin to false and commenting out the menu initializer was very "permanent", and did not permit enabling the plugin by hand on an appliance. This is a requirement, so instead this PR enables the plugin itself, but disables the routes, menu, and API endpoints unless a new `Settings.prototype.migration_analytics.enabled` flag is set to true. It is set to false by default, but can be edited in the Settings page of the UI.