### PR TITLE
Bundle_queue takes targets as [[klass, id]]

### DIFF
--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -13,16 +13,20 @@ module Api
     def bundle_collection(type, data)
       check_feature_enabled
       manifest = self.class.parse_manifest[:body]
+
       provider_ids = data["provider_ids"]
       provider_ids = provider_ids.uniq if provider_ids
       raise "Must specify a list of provider ids via \"provider_ids\"" if provider_ids.blank?
-
       invalid_provider_ids = provider_ids - find_provider_ids(type)
       raise "Invalid provider ids #{invalid_provider_ids.sort.join(', ')} specified" if invalid_provider_ids.present?
 
       desc = "Bundling providers ids: #{provider_ids.join(', ')}"
+
+      userid = User.current_user.userid
+      provider_targets = provider_ids.map { |id| ["ExtManagementSystem", id] }
+
       # bundle takes (userid, manifest, targets, tempdir = nil)
-      task_id = Cfme::CloudServices::InventorySync.bundle_queue(User.current_user.userid, manifest, provider_ids)
+      task_id = Cfme::CloudServices::InventorySync.bundle_queue(userid, manifest, provider_targets)
       action_result(true, desc, :task_id => task_id)
     rescue => e
       action_result(false, e.to_s)

--- a/spec/requests/red_hat_migration_analytics_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_spec.rb
@@ -42,7 +42,8 @@ describe "Red Hat  Migration Analytics Manifest API" do
       ems1 = FactoryBot.create(:ems_vmware, :name => "sample vmware1")
 
       expect(Api::RedHatMigrationAnalyticsController).to receive(:load_manifest).and_return(manifest)
-      allow(Cfme::CloudServices::InventorySync).to receive("bundle_queue").with(@user.userid, manifest, [ems1.id]) { task.id }
+      allow(Cfme::CloudServices::InventorySync).to receive("bundle_queue")
+        .with(@user.userid, manifest, [["ExtManagementSystem", ems1.id]]) { task.id }
 
       post(api_red_hat_migration_analytics_url,
            :params => {


### PR DESCRIPTION
We need to pass targets to InventorySync.bundle_queue as [klass, id]
pairs not just an array of ids.