### PR TITLE
Put the payload in public/migration_analytics

### DIFF
--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -24,9 +24,11 @@ module Api
 
       userid = User.current_user.userid
       provider_targets = provider_ids.map { |id| ["ExtManagementSystem", id] }
+      public_download_dir = Rails.root.join("public", "migration_analytics")
+      Dir.mkdir public_download_dir unless public_download_dir.exist?
 
       # bundle takes (userid, manifest, targets, tempdir = nil)
-      task_id = Cfme::CloudServices::InventorySync.bundle_queue(userid, manifest, provider_targets)
+      task_id = Cfme::CloudServices::InventorySync.bundle_queue(userid, manifest, provider_targets, public_download_dir)
       action_result(true, desc, :task_id => task_id)
     rescue => e
       action_result(false, e.to_s)

--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -26,9 +26,12 @@ module Api
       provider_targets = provider_ids.map { |id| ["ExtManagementSystem", id] }
       public_download_dir = Rails.root.join("public", "migration_analytics")
       Dir.mkdir public_download_dir unless public_download_dir.exist?
+      file_permissions = 0644
 
       # bundle takes (userid, manifest, targets, tempdir = nil)
-      task_id = Cfme::CloudServices::InventorySync.bundle_queue(userid, manifest, provider_targets, public_download_dir)
+      task_id = Cfme::CloudServices::InventorySync.bundle_queue(
+        userid, manifest, provider_targets, public_download_dir, file_permissions)
+
       action_result(true, desc, :task_id => task_id)
     rescue => e
       action_result(false, e.to_s)

--- a/spec/requests/red_hat_migration_analytics_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_spec.rb
@@ -42,8 +42,11 @@ describe "Red Hat  Migration Analytics Manifest API" do
       ems1 = FactoryBot.create(:ems_vmware, :name => "sample vmware1")
 
       expect(Api::RedHatMigrationAnalyticsController).to receive(:load_manifest).and_return(manifest)
+
+      expected_targets = [["ExtManagementSystem", ems1.id]]
+      expected_tempdir = Rails.root.join("public", "migration_analytics")
       allow(Cfme::CloudServices::InventorySync).to receive("bundle_queue")
-        .with(@user.userid, manifest, [["ExtManagementSystem", ems1.id]]) { task.id }
+        .with(@user.userid, manifest, expected_targets, expected_tempdir) { task.id }
 
       post(api_red_hat_migration_analytics_url,
            :params => {

--- a/spec/requests/red_hat_migration_analytics_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_spec.rb
@@ -45,8 +45,9 @@ describe "Red Hat  Migration Analytics Manifest API" do
 
       expected_targets = [["ExtManagementSystem", ems1.id]]
       expected_tempdir = Rails.root.join("public", "migration_analytics")
+      expected_perm    = 0644
       allow(Cfme::CloudServices::InventorySync).to receive("bundle_queue")
-        .with(@user.userid, manifest, expected_targets, expected_tempdir) { task.id }
+        .with(@user.userid, manifest, expected_targets, expected_tempdir, expected_perm) { task.id }
 
       post(api_red_hat_migration_analytics_url,
            :params => {


### PR DESCRIPTION
Allow the tgz to be downloaded from the webserver by placing it in the
public/ directory.

Depends on: ~~https://github.com/RedHatCloudForms/cfme-cloud_services/pull/42~~