### PR TITLE
Update default-manifest with v_parent_datacenter

### DIFF
--- a/config/default-manifest.json
+++ b/config/default-manifest.json
@@ -14,7 +14,7 @@
         "name": null
       }
     },
-    "ManageIQ::Providers::OpenStack::CloudManager": {
+    "ManageIQ::Providers::Openstack::CloudManager": {
       "id": null,
       "name": null,
       "type": null,
@@ -160,7 +160,8 @@
         "ha_enabled": null,
         "drs_enabled": null,
         "effective_cpu": null,
-        "effective_memory": null
+        "effective_memory": null,
+        "v_parent_datacenter": null
       },
       "hosts": {
         "id": null,
@@ -300,7 +301,8 @@
         "ha_enabled": null,
         "drs_enabled": null,
         "effective_cpu": null,
-        "effective_memory": null
+        "effective_memory": null,
+        "v_parent_datacenter": null
       },
       "hosts": {
         "id": null,


### PR DESCRIPTION
Update the default-manifest to sync it with the one on cloud.redhat.com

This rolls up the following PRs:
https://github.com/ManageIQ/topological_inventory-api/pull/227
https://github.com/ManageIQ/topological_inventory-api/pull/234