### PR TITLE
Use React.createRef to prevent eslint override, restore commented-out tests

### DIFF
--- a/.jest-setup.js
+++ b/.jest-setup.js
@@ -23,3 +23,7 @@ global.$ = jest.fn(() => ({
   on: jest.fn(),
   selectpicker: jest.fn()
 }));
+
+Object.defineProperty(global.document, 'queryCommandSupported', {
+  value: () => true
+});

--- a/app/javascript/react/screens/App/Analytics/screens/AnalyticsDataCollection/AnalyticsDataCollection.js
+++ b/app/javascript/react/screens/App/Analytics/screens/AnalyticsDataCollection/AnalyticsDataCollection.js
@@ -7,6 +7,7 @@ class AnalyticsDataCollection extends React.Component {
   constructor(props) {
     super(props);
     this.fetchBundleTaskTimeout = null;
+    this.scpSpanRef = React.createRef();
   }
 
   clearTimer = () => {
@@ -16,7 +17,7 @@ class AnalyticsDataCollection extends React.Component {
 
   copyToClipboard = e => {
     const range = document.createRange();
-    range.selectNode(this.span);
+    range.selectNode(this.scpSpanRef.current);
     window.getSelection().removeAllRanges();
     window.getSelection().addRange(range);
     document.execCommand('copy');
@@ -100,11 +101,7 @@ class AnalyticsDataCollection extends React.Component {
             <br />
             {__('To download the saved inventory data, copy the command below and run it from a command line.')}
             <br />
-            <span
-              className="payload-path"
-              /* eslint no-return-assign: "error" */
-              ref={span => (this.span = span)}
-            >{`scp root@${payloadHost}:${payloadPath} .`}</span>
+            <span className="payload-path" ref={this.scpSpanRef}>{`scp root@${payloadHost}:${payloadPath} .`}</span>
           </p>
           <div className="buttons">
             {document.queryCommandSupported('copy') && (

--- a/app/javascript/react/screens/App/Analytics/screens/AnalyticsDataCollection/__tests__/AnalyticsDataCollection.test.js
+++ b/app/javascript/react/screens/App/Analytics/screens/AnalyticsDataCollection/__tests__/AnalyticsDataCollection.test.js
@@ -14,20 +14,21 @@ describe('Data collection screen', () => {
     expect(shallow(<AnalyticsDataCollection {...getBaseProps()} />)).toMatchSnapshot();
   });
 
-  /*
-  test('renders a success message with a download button after payload is loaded', () => {
+  test('renders a success message and payload path after payload is loaded', () => {
     const props = {
       ...getBaseProps(),
       isPayloadReady: true,
       numVms: 7,
       payloadPath: 'some/path/to/payload.tgz',
-      payloadUrl: 'fake/url/here/payload.tgz'
+      payloadHost: 'some.host'
     };
     const component = shallow(<AnalyticsDataCollection {...props} />);
     expect(component).toMatchSnapshot();
   });
 
-  test('renders a success message with disabled button if there is no download url', () => {
+  // Disabled until we figure out how to download the payload safely over http
+  // eslint-disable-next-line jest/no-disabled-tests
+  test.skip('renders a success message with disabled button if there is no download url', () => {
     const props = {
       ...getBaseProps(),
       isPayloadReady: true,
@@ -37,5 +38,4 @@ describe('Data collection screen', () => {
     const component = shallow(<AnalyticsDataCollection {...props} />);
     expect(component).toMatchSnapshot();
   });
-  */
 });

--- a/app/javascript/react/screens/App/Analytics/screens/AnalyticsDataCollection/__tests__/__snapshots__/AnalyticsDataCollection.test.js.snap
+++ b/app/javascript/react/screens/App/Analytics/screens/AnalyticsDataCollection/__tests__/__snapshots__/AnalyticsDataCollection.test.js.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Data collection screen renders a success message and payload path after payload is loaded 1`] = `
+<div
+  className="data-collection-status icon-with-content"
+>
+  <Icon
+    className="checkmark"
+    name="check"
+    type="fa"
+  />
+  <div>
+    <h3>
+      Inventory collection complete
+    </h3>
+    <p>
+      7
+       
+      VMs examined
+      <br />
+      To download the saved inventory data, copy the command below and run it from a command line.
+      <br />
+      <span
+        className="payload-path"
+      >
+        scp root@some.host:some/path/to/payload.tgz .
+      </span>
+    </p>
+    <div
+      className="buttons"
+    >
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="primary"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Copy to Clipboard
+      </Button>
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        disabled={false}
+        onClick={[MockFunction]}
+      >
+        Return to Summary
+      </Button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Data collection screen renders with a spinner initially 1`] = `
 <div
   className="data-collection-status icon-with-content"


### PR DESCRIPTION
This is just a very minor cleanup to address feedback I would have given on #20. Instead of having to use `/* eslint no-return-assign: "error" */` to prevent issues with the callback ref, we can use `React.createRef()` to avoid using an assignment there.

Also, rather than commenting out the broken unit tests, I fixed the first one (by mocking document.queryCommandSupported) and disabled the second one using `jest.skip`.

Thanks for your implementation on #20 @mzazrivec, it works great.