### PR TITLE
Implement upload of the manifest.

### DIFF
--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -74,9 +74,7 @@ module Api
       end
 
       def store_manifest(manifest)
-        File.open(user_manifest_path, 'w') do |f|
-          f.write(JSON.generate(manifest))
-        end
+        user_manifest_path.write(JSON.generate(manifest))
       end
 
       def parse_manifest

--- a/config/api.yml
+++ b/config/api.yml
@@ -15,3 +15,8 @@
       :post:
       - :name: bundle
         :identifier: red_hat_migration_analytics
+      - :name: import_manifest
+        :identifier: red_hat_migration_analytics
+      - :name: reset_manifest
+        :identifier: red_hat_migration_analytics
+

--- a/spec/requests/red_hat_migration_analytics_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_spec.rb
@@ -12,6 +12,7 @@ describe "Red Hat  Migration Analytics Manifest API" do
       end
 
       it "with the built-in manifest" do
+        expect(Api::RedHatMigrationAnalyticsController).to receive(:user_manifest_path).and_return(Pathname.new('/non-existent-file'))
         get(api_red_hat_migration_analytics_url)
 
         expect(response).to have_http_status(:ok)
@@ -25,6 +26,7 @@ describe "Red Hat  Migration Analytics Manifest API" do
           "ssh_key_data"  => nil
         }
 
+        expect(Api::RedHatMigrationAnalyticsController).to receive(:user_manifest_path).and_return(Pathname.new('/non-existent-file'))
         expect(Api::RedHatMigrationAnalyticsController).to receive(:load_manifest).and_return(malicious_manifest)
 
         get(api_red_hat_migration_analytics_url)
@@ -55,6 +57,41 @@ describe "Red Hat  Migration Analytics Manifest API" do
         "success" => true,
         "message" => "Bundling providers ids: #{ems1.id}",
         "task_id" => "#{task.id}"
+      )
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "/api/red_hat_migration_analytics/:id import_manifest action" do
+      api_basic_authorize "red_hat_migration_analytics"
+
+      expect(Api::RedHatMigrationAnalyticsController).to receive(:store_manifest)
+
+      post(api_red_hat_migration_analytics_url,
+           :params => {
+             "action"   => "import_manifest",
+             "manifest" => { "foo" => "bar "}
+      })
+
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "message" => "imported manifest"
+      )
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "/api/red_hat_migration_analytics/:id reset_manifest action" do
+      api_basic_authorize "red_hat_migration_analytics"
+
+      expect(Api::RedHatMigrationAnalyticsController).to receive(:user_manifest_path).and_return(Pathname.new('/non-existent-file'))
+
+      post(api_red_hat_migration_analytics_url,
+           :params => {
+             "action"       => "reset_manifest"
+      })
+
+      expect(response.parsed_body).to include(
+        "success" => true,
+        "message" => "manifest does not exist"
       )
       expect(response).to have_http_status(:ok)
     end


### PR DESCRIPTION
* upload new manifest                                                                      
  * a) replace existing (uploaded one)                                                      
  * b) use instead of the default one (provided with V2V)                                   

  Store it in `/opt/rh/cfme-migration_analytics/manifest.json`
  Manifest is passed as JSON in the body of a POST request.

 * delete uploaded manifest using HTTP ~~DELETE~~ *using POST instead*
    this restores the original manifest config/default-manifest.json                         

Usage:

**$ api get red_hat_migration_analytics**
```
{
  "manifest_version": "1.0.0",
  "using_default_manifest": true
}
```

Now upload the manifest:
**$ echo '{ "action": "import_manifest", "manifest": { "foo": "bar" } }' | api post red_hat_migration_analytics**
```
{
  "success": true,
  "message": "imported manifest"
}
```

See how it went:
**$ api get red_hat_migration_analytics**
```
{
  "manifest_version": null,
  "default_manifest_version": "1.0.0",
  "using_default_manifest": false
}
```

Now reset the manifest:
**$ echo '{ "action": "reset_manifest" }' | api post red_hat_migration_analytics**
```
{
  "success": true,
  "message": "deleted manifest"
}
```

Check again:
**$ api get red_hat_migration_analytics**
```
{
  "manifest_version": "1.0.0",
  "using_default_manifest": true
}
```

Part of: https://github.com/RedHatCloudForms/cfme-migration_analytics/issues/27

https://bugzilla.redhat.com/show_bug.cgi?id=1788729