### PR TITLE
Drop host_storages.ems_ref from default manifest to prevent payload collection error

### DIFF
--- a/config/default-manifest.json
+++ b/config/default-manifest.json
@@ -214,7 +214,6 @@
         "uncommitted": null,
         "storage_domain_type": null,
         "host_storages": {
-          "ems_ref": null,
           "host": {
             "ems_ref": null
           }
@@ -363,7 +362,6 @@
         "uncommitted": null,
         "storage_domain_type": null,
         "host_storages": {
-          "ems_ref": null,
           "host": {
             "ems_ref": null
           }


### PR DESCRIPTION
Ever since https://github.com/ManageIQ/manageiq-schema/pull/326, the payload collection in Migration Analytics has been broken with the following error:

<img width="753" alt="Screenshot 2020-01-20 13 17 24" src="https://user-images.githubusercontent.com/811963/72752650-c1255480-3b90-11ea-95c3-aee28f73b3c3.png">

This PR removes the now-missing `host_storages.ems_ref` property from the manifest and resolves the error.