### PR TITLE
Add a separate controller for payload download.

### DIFF
--- a/app/controllers/api/mixins/feature_check.rb
+++ b/app/controllers/api/mixins/feature_check.rb
@@ -1,0 +1,11 @@
+module Api
+  module Mixins
+    module FeatureCheck
+      def check_feature_enabled
+        unless Settings.prototype.migration_analytics.enabled
+          raise ActionController::RoutingError, 'Feature Not Enabled'
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/red_hat_migration_analytics_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class RedHatMigrationAnalyticsController < BaseController
+    include Api::Mixins::FeatureCheck
+
     def index
       check_feature_enabled
       manifest = self.class.parse_manifest
@@ -51,12 +53,6 @@ module Api
     end
 
     private
-
-    def check_feature_enabled
-      unless Settings.prototype.migration_analytics.enabled
-        raise ActionController::RoutingError, 'Feature Not Enabled'
-      end
-    end
 
     def find_provider_ids(type)
       providers, _ = collection_search(false, :providers, collection_class(:providers))

--- a/app/controllers/api/red_hat_migration_analytics_payload_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_payload_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  class RedHatMigrationAnalyticsPayloadController < BaseController
+    def index
+      check_feature_enabled
+      task_id = params['task_id']
+      raise "Must specify a task id via \"task_id\"" if task_id.blank?
+
+      begin
+        task = MiqTask.find(task_id)
+        path = task&.context_data&.fetch(:payload_path, nil)
+        if path && File.exist?(path)
+          send_file(path, :type => 'application/binary')
+        else
+          raise "Payload not found."
+        end
+      end
+    end
+
+    private
+
+    def check_feature_enabled
+      unless Settings.prototype.migration_analytics.enabled
+        raise ActionController::RoutingError, 'Feature Not Enabled'
+      end
+    end
+  end
+end

--- a/app/controllers/api/red_hat_migration_analytics_payload_controller.rb
+++ b/app/controllers/api/red_hat_migration_analytics_payload_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class RedHatMigrationAnalyticsPayloadController < BaseController
+    include Api::Mixins::FeatureCheck
+
     def index
       check_feature_enabled
       task_id = params['task_id']
@@ -13,14 +15,6 @@ module Api
         else
           raise "Payload not found."
         end
-      end
-    end
-
-    private
-
-    def check_feature_enabled
-      unless Settings.prototype.migration_analytics.enabled
-        raise ActionController::RoutingError, 'Feature Not Enabled'
       end
     end
   end

--- a/config/api.yml
+++ b/config/api.yml
@@ -19,4 +19,15 @@
         :identifier: red_hat_migration_analytics
       - :name: reset_manifest
         :identifier: red_hat_migration_analytics
-
+  :red_hat_migration_analytics_payload:
+    :description: Red Hat Migration Analytics Payload
+    :options:
+    - :arbitrary_resource_path
+    - :collection
+    :identifier: red_hat_migration_analytics
+    :verbs:
+    - :get
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: red_hat_migration_analytics

--- a/spec/requests/red_hat_migration_analytics_payload_spec.rb
+++ b/spec/requests/red_hat_migration_analytics_payload_spec.rb
@@ -1,0 +1,43 @@
+describe "Red Hat  Migration Analytics Payload API" do
+  let(:url) { "#{api_url}/red_hat_migration_analytics_payload" }
+  let(:manifest) { { "ManageIQ::Providers::Vmware::InfraManager" => {}} }
+  let(:payload_path) { __FILE__ }
+  let(:task) { FactoryBot.create(:miq_task, :context_data => {:payload_path => payload_path}) }
+  let(:empty_task) { FactoryBot.create(:miq_task) }
+
+  before { stub_settings_merge(:prototype => {:migration_analytics => {:enabled => true}}) }
+
+  describe "GET" do
+    context "/api/red_hat_migration_analytics_payload" do
+      before do
+        api_basic_authorize "red_hat_migration_analytics"
+      end
+
+      it "returns the payload is present in the Task" do
+        allow(MiqTask).to receive(:find).and_return(task)
+        get(url, :params => {:task_id => task.id})
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match(/tady je Krakonosovo/)
+      end
+
+      it "fails if no payload is present in the Task" do
+        allow(MiqTask).to receive(:find).and_return(empty_task)
+        get(url, :params => {:task_id => empty_task.id})
+        expect(response).to have_http_status(500)
+      end
+
+      it "fails if task_id is passed" do
+        get(url)
+        expect(response).to have_http_status(500)
+      end
+    end
+
+    context "/api/red_hat_migration_analytics_payload" do
+      it "denies w/o authorization" do
+        allow(MiqTask).to receive(:find).and_return(task)
+        get(url, :params => {:task_id => task.id})
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I implemented the option a) from https://github.com/RedHatCloudForms/cfme-migration_analytics/pull/33

I did not figure how to make a "arbitrary" method other thatn `index` or `show` using what is available in the API. (calling `send_file` from other methods does now work due to assumptions in the API code).

example usage: `curl -i -u admin:smartvm http://localhost:3000/api/red_hat_migration_analytics_payload?task_id=30`

@lpichler: do you have an idea how to do this in a the existing controller?

@mturley: can you, please, try if this works for you (with use of the `file-saver` package)?

### TODO:

if we agree on this approach I will:
 * ~~move the duplicated method to a mixin~~
 * ~~write some test~~

-------
BZ for backport to ivanchuk: https://bugzilla.redhat.com/show_bug.cgi?id=1788730
JIRA task for feature: https://issues.redhat.com/browse/MIGENG-241
