### PR TITLE
Change labels in Update Manifest modal

### DIFF
--- a/app/javascript/react/screens/App/Analytics/components/ManifestUpdateModal.js
+++ b/app/javascript/react/screens/App/Analytics/components/ManifestUpdateModal.js
@@ -17,23 +17,17 @@ const ManifestUpdateModal = ({ onClose, manifestInfo, uploadManifestAction, rese
           <Modal.Body>
             <Grid.Row className="show-grid">
               <Grid.Col xs={6} className="text-right">
-                {__('Current manifest version')}:
+                {__('Manifest version')}:
               </Grid.Col>
               <Grid.Col xs={6}>{manifestInfo.manifest_version}</Grid.Col>
-            </Grid.Row>
-            <Grid.Row className="show-grid">
-              <Grid.Col xs={6} className="text-right">
-                {__('Default manifest version')}:
-              </Grid.Col>
-              <Grid.Col xs={6}>{manifestInfo.default_manifest_version}</Grid.Col>
             </Grid.Row>
           </Modal.Body>
           <Modal.Footer>
             <Button bsStyle="default" onClick={resetManifestAction} disabled={manifestInfo.using_default_manifest}>
-              {__('Restore default manifest')}
+              {__('Restore Manifest Version')} {manifestInfo.default_manifest_version}
             </Button>
             <Button bsStyle="default" onClick={openFileBrowser}>
-              {__('Upload new manifest')}
+              {__('Update Manifest')}
             </Button>
             <Button bsStyle="primary" className="btn-cancel" onClick={onClose}>
               {__('Close')}


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-496
https://bugzilla.redhat.com/show_bug.cgi?id=1814875

This PR makes the labels in the Update Manifest modal a bit more intuitive.

# Screens

Initial state (no manifest update has been performed yet):
<img width="604" alt="Screenshot 2020-03-19 09 22 50" src="https://user-images.githubusercontent.com/811963/77071999-5d1de180-69c3-11ea-8a08-88c042409a9f.png">


State with Restore function available (after updating to manifest 1.0.5):
<img width="604" alt="Screenshot 2020-03-19 09 23 05" src="https://user-images.githubusercontent.com/811963/77071994-5abb8780-69c3-11ea-8c08-c3336437b5fc.png">

